### PR TITLE
Update README.md to include Open VSX Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ### Marketplace
 
-You can find my icons on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=littensy.charmed-icons).
+You can find my icons on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=littensy.charmed-icons) or on the [Open VSX Registry](https://open-vsx.org/extension/littensy/charmed-icons).
 
 ### Manual
 


### PR DESCRIPTION
Adds a link to the Open VSX Registry under the Usage section. The registry allows for VSCode compatible editors to use an extension marketplace rather than a proprietary Microsoft owned one.