### PR TITLE
feat: add binary icons for non windows systems

### DIFF
--- a/src/defaults/file-icons.ts
+++ b/src/defaults/file-icons.ts
@@ -21,7 +21,7 @@ export const fileIcons: FileIcons = {
 	},
 	"binary": {
 		languages: ["code-text-binary"],
-		extensions: ["bin", "exe", "msi", "dll", "pdb", "lib", "so", "dylib", "o", "obj", "a"],
+		extensions: ["bin", "exe", "msi", "dll", "lib", "so", "dylib", "o", "obj", "a"],
 	},
 	"bun": {
 		names: ["bun.lock", "bun.lockb", "bunfig.toml"],


### PR DESCRIPTION
pdb: Windows debugging symbols
lib: Windows static/import libraries
so: Linux shared object
dylib: macOS dynamic library
o, obj: object file
a: archive